### PR TITLE
Don't cross-compile releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master
-      - uses: docker/setup-qemu-action@v1
-        if: matrix.os == 'Ubuntu' && github.event_name == 'release' && github.event.action == 'published'
-        with:
-          platforms: all
+#       - uses: docker/setup-qemu-action@v1
+#         if: matrix.os == 'Ubuntu' && github.event_name == 'release' && github.event.action == 'published'
+#         with:
+#           platforms: all
       - run: echo '::add-matcher::.github/problem-matchers/gcc.json'
         if: matrix.os == 'macOS' || matrix.os == 'Ubuntu'
       - run: echo '::add-matcher::.github/problem-matchers/msvc.json'
@@ -47,7 +47,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_ARCHS: "${{ github.event_name == 'release' && github.event.action == 'published' && 'all' || 'auto' }}"
+#           CIBW_ARCHS: "${{ github.event_name == 'release' && github.event.action == 'published' && 'all' || 'auto' }}"
           CIBW_BEFORE_BUILD: pip install -r {project}/requirements.txt
           CIBW_BUILD: cp${{ matrix.major }}${{ matrix.minor }}-*
           CIBW_BUILD_VERBOSITY: 1


### PR DESCRIPTION
This drops formal support for the `aarch64`, `s390x`, and `ppc64le` architectures.