### PR TITLE
Update dtype references when creation of new array fails

### DIFF
--- a/src/_arraykit.c
+++ b/src/_arraykit.c
@@ -198,11 +198,12 @@ AK_ArrayDeepCopy(PyArrayObject *array, PyObject *memo)
                 array,
                 dtype,
                 NPY_ARRAY_ENSURECOPY);
-        if (memo) {
-            if (!array_new || PyDict_SetItem(memo, id, array_new)) {
-                Py_XDECREF(array_new);
-                goto error;
-            }
+        if (!array_new) { // we unnecessarily incref'ed the dtype
+            Py_DECREF(dtype);
+        }
+        else if (memo && PyDict_SetItem(memo, id, array_new)) {
+            Py_XDECREF(array_new);
+            goto error;
         }
     }
     // set immutable

--- a/src/_arraykit.c
+++ b/src/_arraykit.c
@@ -201,8 +201,8 @@ AK_ArrayDeepCopy(PyArrayObject *array, PyObject *memo)
         if (!array_new) { // we unnecessarily incref'ed the dtype
             goto error;
         }
-        else if (memo && PyDict_SetItem(memo, id, array_new)) {
-            Py_XDECREF(array_new);
+        if (memo && PyDict_SetItem(memo, id, array_new)) {
+            Py_DECREF(array_new);
             goto error;
         }
     }

--- a/src/_arraykit.c
+++ b/src/_arraykit.c
@@ -199,7 +199,7 @@ AK_ArrayDeepCopy(PyArrayObject *array, PyObject *memo)
                 dtype,
                 NPY_ARRAY_ENSURECOPY);
         if (!array_new) { // we unnecessarily incref'ed the dtype
-            Py_DECREF(dtype);
+            goto error;
         }
         else if (memo && PyDict_SetItem(memo, id, array_new)) {
             Py_XDECREF(array_new);

--- a/src/_arraykit.c
+++ b/src/_arraykit.c
@@ -198,7 +198,7 @@ AK_ArrayDeepCopy(PyArrayObject *array, PyObject *memo)
                 array,
                 dtype,
                 NPY_ARRAY_ENSURECOPY);
-        if (!array_new) { // we unnecessarily incref'ed the dtype
+        if (!array_new) {
             goto error;
         }
         if (memo && PyDict_SetItem(memo, id, array_new)) {


### PR DESCRIPTION
My guess is that dtype needs to be decre'fed in this case. Therefore, I made this change. My understanding on the steal/borrow concept on this might be incorrect. 

Edit: Also, I would appreciate suggestions on how to test this change (if the change is valid)